### PR TITLE
Report errors from mclapply

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pulsar
 Title: Parallel Utilities for Lambda Selection along a Regularization Path
-Version: 0.3.5
+Version: 0.3.6
 Encoding: UTF-8
 Authors@R: c(person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
              person("Christian", "M\u00FCller", role = c("aut", "ctb"), email="cmueller@simonsfoundation.org"))

--- a/R/mcPulsarSelect.R
+++ b/R/mcPulsarSelect.R
@@ -200,7 +200,7 @@ pulsar <- function(data, fun=huge::huge, fargs=list(),
   } else minN <- rep.num + refit
 
   isamp <- ind.sample[1L:minN]
-  ## don't pass on errors if lb.stars mode
+  ## don't pass on errors if lb.stars = TRUE
   premerge <- .try_mclapply(isamp, estFun, fargs = fargs, mc.cores = ncores,
                             mc.preschedule = FALSE, pass.errors = !lb.stars)
   errors <- attr(premerge, 'errors')

--- a/R/mcPulsarSelect.R
+++ b/R/mcPulsarSelect.R
@@ -37,6 +37,7 @@
 
 }
 
+#' @importFrom parallel mclapply
 #' @keywords internal
 .tlist <- function(li, n, m) {
   if (missing(m)) m <- length(li)
@@ -44,6 +45,49 @@
     lapply(1L:m, function(j) li[[j]][[i]])
   })
 }
+
+#' @keywords internal
+.try_mclapply <- function(X, FUN, mc.cores = getOption("mc.cores", 2L),
+                          pass.errors=TRUE, ...) {
+  ## capture errors/warnings from mclapply
+  warn <- NULL
+  env <- environment()
+  withCallingHandlers({out <- mclapply(X, FUN, mc.cores=mc.cores, ...)},
+                      warning=function(w) {
+                         # why doesn't assignment mode work when ncores>1
+                         assign('warn', c(warn, w$message), env)
+                         invokeRestart("muffleWarning")
+                       })
+  ## handle errors
+  errors <- sapply(out, inherits, what="try-error")
+  if (any(errors)) {
+    error <- table(trimws(sapply(out[errors], '[', 1)))
+    msg   <- paste(sprintf('\n%s job%s failed with: "%s"',
+                  error, ifelse(error>1, 's', ''), names(error)), collapse="" )
+    if (!pass.errors || all(errors)) {
+      stop(msg, call.=FALSE)
+    } else {
+      warning(msg, call.=FALSE)
+      ## continue with successful jobs
+      out <- out[!errors]
+    }
+  } else {
+    ## will only invoke if ncore=1, otherwise mclapply suppresses warnings
+    if (length(warn) > 0) {
+      twarn <- table(trimws(sapply(warn, '[', 1)))
+      msg   <- paste(sprintf('%s job%s had warning: "%s"',
+                              twarn, ifelse(twarn>1, 's', ''), names(twarn)),
+                      collapse="\n")
+      warning(msg, call.=FALSE)
+    }
+  }## no errors detected, continue
+
+  # reset previous warn option
+  # options(warn=warn.opt)
+  attr(out, 'errors') <- errors
+  return(out)
+}
+
 
 #' pulsar: serial or parallel mode
 #'
@@ -156,8 +200,13 @@ pulsar <- function(data, fun=huge::huge, fargs=list(),
   } else minN <- rep.num + refit
 
   isamp <- ind.sample[1L:minN]
-  ## TODO: set global options for mc.* args to parallel::mclapply
-  premerge <- mclapply(isamp, estFun, fargs=fargs, mc.cores=ncores)
+  ## don't pass on errors if lb.stars mode
+  premerge <- .try_mclapply(isamp, estFun, fargs = fargs, mc.cores = ncores,
+                            mc.preschedule = FALSE, pass.errors = !lb.stars)
+  errors <- attr(premerge, 'errors')
+  # Adjust rep.num for failed jobs
+  rep.num <- rep.num - ifelse(refit, sum(errors[-1]), sum(errors))
+
   if (refit) {
     fullmodel <- premerge[[1]]
     premerge  <- premerge[-1]
@@ -188,7 +237,11 @@ pulsar <- function(data, fun=huge::huge, fargs=list(),
     lb.premerge  <- lapply(lb.premerge,
                            function(ppm) ppm[ub.index:lb.est$opt.index])
     isamp <- ind.sample[-(1L:(minN+refit))]
-    tmp   <- mclapply(isamp, estFun, fargs=fargs, mc.cores=ncores)
+#    tmp   <- mclapply(isamp, estFun, fargs=fargs, mc.cores=ncores, mc.preschedule = FALSE)
+    tmp <- .try_mclapply(isamp, estFun, fargs = fargs, mc.cores = ncores,
+                         mc.preschedule = FALSE)
+    # Adjust rep.num for failed jobs
+    rep.num <- rep.num - sum(attr(tmp, 'errors'))
     premerge <- c(lb.premerge, tmp)
   }
 

--- a/tests/testthat/test_errorreporting.R
+++ b/tests/testthat/test_errorreporting.R
@@ -7,7 +7,7 @@ set.seed(rseed)
 dat <- huge::huge.generator(p*5, p, "hub", verbose=FALSE, v=.4, u=.2)
 set.seed(rseed)
 X <- MASS::mvrnorm(p*5, mu=rep(0,p), Sigma=dat$sigma, empirical=TRUE)
-X[4,] <- NA
+X[4,] <- NA ## sample 4 not in first two subsamples, given rseed
 
 # TODO: test only a subset of jobs failing
 huge_error <- function(data, lambda, f=stop, ...) {
@@ -38,12 +38,13 @@ test_that("Job stops when every parallel job has errors", {
           rep.num=8, refit=FALSE, lb.stars=TRUE),
     regexp = "NA")
 
-
+  skip_on_os("windows")
   expect_error(
     pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
           rep.num=8, refit=FALSE),
     regexp = "NA")
 
+  skip_on_os("windows")
   expect_error(
     pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
           rep.num=8, refit=FALSE, lb.stars=TRUE),
@@ -64,13 +65,14 @@ test_that("Job continues when subset of parallel jobs have errors/warnings", {
           rep.num=8, refit=FALSE, lb.stars=TRUE),
     regexp = "NA")
 
-
+  skip_on_os("windows")
   expect_warning(
     filter_warning(
       out1 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,
             seed=rseed, rep.num=8, refit=FALSE), "Optimal lambda"),
     regexp = "NA")
 
+  skip_on_os("windows")
   expect_warning(
     filter_warning(
       out2 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,

--- a/tests/testthat/test_errorreporting.R
+++ b/tests/testthat/test_errorreporting.R
@@ -1,0 +1,99 @@
+context("error reporting")
+
+
+p <- 4
+rseed <- 10010
+set.seed(rseed)
+dat <- huge::huge.generator(p*5, p, "hub", verbose=FALSE, v=.4, u=.2)
+set.seed(rseed)
+X <- MASS::mvrnorm(p*5, mu=rep(0,p), Sigma=dat$sigma, empirical=TRUE)
+X[4,] <- NA
+
+# TODO: test only a subset of jobs failing
+huge_error <- function(data, lambda, f=stop, ...) {
+  if (any(is.na(data))) {
+    f('NA detected in data', call.=FALSE)
+  }
+  return(huge::huge(na.exclude(data), lambda=lambda, ...))
+}
+
+filter_warning <- function(expr, regxpr) {
+  withCallingHandlers(
+    force(expr),
+  warning=function(w) {
+     if (grepl(regxpr, w$message))
+        invokeRestart("muffleWarning")
+  } )
+}
+
+hargs <- list(lambda=getLamPath(1, .005, 10), verbose=FALSE, f=stop)
+test_that("Job stops when every parallel job has errors", {
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=1, seed=rseed,
+          rep.num=8, refit=FALSE),
+    regexp = "NA")
+
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=1, seed=rseed,
+          rep.num=8, refit=FALSE, lb.stars=TRUE),
+    regexp = "NA")
+
+
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
+          rep.num=8, refit=FALSE),
+    regexp = "NA")
+
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
+          rep.num=8, refit=FALSE, lb.stars=TRUE),
+    regexp = "NA")
+
+})
+
+
+test_that("Job continues when subset of parallel jobs have errors/warnings", {
+  hargs$f <- stop
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=.5, seed=rseed,
+          rep.num=8, refit=FALSE),
+    regexp = "NA")
+
+  expect_error(
+    pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=.5, seed=rseed,
+          rep.num=8, refit=FALSE, lb.stars=TRUE),
+    regexp = "NA")
+
+
+  expect_warning(
+    filter_warning(
+      out1 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,
+            seed=rseed, rep.num=8, refit=FALSE), "Optimal lambda"),
+    regexp = "NA")
+
+  expect_warning(
+    filter_warning(
+      out2 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,
+            seed=rseed, rep.num=8, refit=FALSE, lb.stars=TRUE),
+      "Optimal lambda"),
+    regexp = "NA")
+
+  expect_equivalent(out1$stars$opt.ind, out2$stars$opt.ind)
+
+  hargs$f <- warning
+  expect_warning(
+    filter_warning(
+      out1 <- pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=.5,
+             seed=rseed, rep.num=8, refit=FALSE), "Optimal lambda"),
+    regexp = "NA")
+
+  expect_warning(
+    filter_warning(
+      out2 <- pulsar(X, fun=huge_error, hargs, ncores=1, subsample.ratio=.5,
+             seed=rseed, rep.num=8, refit=FALSE, lb.stars=TRUE),
+      "Optimal lambda"),
+    regexp = "NA")
+
+  expect_equivalent(out1$stars$opt.ind, out2$stars$opt.ind)
+
+})


### PR DESCRIPTION
Captures errors from mclapply jobs and:

1) Throw errors if all jobs fail
2) Continue if subset of jobs fail, convert errors to warnings, return successful jobs and adjust denominator of summary statistic
3) If 1 core, report warnings gracefully.
4) Test behavior of above conditions in multicore and lower-bound mode.

Addresses issue #14 here and https://github.com/zdk123/SpiecEasi/issues/80