### PR TITLE
Future-proof Matrix 1.4-2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pulsar
 Title: Parallel Utilities for Lambda Selection along a Regularization Path
-Version: 0.3.7
+Version: 0.3.8
 Encoding: UTF-8
 Authors@R: c(person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
              person("Christian", "M\u00FCller", role = c("aut", "ctb"), email="cmueller@simonsfoundation.org"))

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
-pulsar 0.3.7 (7-202020 Release)
+pulsar 0.3.8 (8-2022 Release)
+==============
+
+* Future-proof sparse Matrix convertors for Matrix-1.4-2 in code and docs
+* Fix one S3 class check
+
+pulsar 0.3.7 (7-2020 Release)
 ==============
 
 * Remove the deprecated QUIC package from suggested packages in DESCRIPTION file.

--- a/R/graphFeatures.R
+++ b/R/graphFeatures.R
@@ -150,7 +150,7 @@ subgraph.centrality <- function(Graph, eigs=NULL, rmdiag=FALSE) {
 #' @references Estrada, E. (2007). Topological structural classes of complex networks. Physical Review E - Statistical, Nonlinear, and Soft Matter Physics, 75(1), 1-12. doi:10.1103/PhysRevE.75.016103
 #' @export
 estrada.class <- function(G, evthresh=1e-3) {
-  if (class(G) != "subgraph.centrality")
+  if (!inherits(G, "subgraph.centrality"))
       G <- subgraph.centrality(G)
 
   ev1  <- G$evec[,1]

--- a/R/graphFeatures.R
+++ b/R/graphFeatures.R
@@ -30,10 +30,6 @@ GraphDiss2 <- function(G) {
     1 - (Gprod / sqrt(degProd))
 }
 
-## DEPRECATED WITHOUT rARPACK
-##eigs_sym.dsCMatrix <- function(A, ...) {
-##    eigs_sym(as(A, 'dgCMatrix'), ...)
-##}
 
 #' Natural Connectivity
 #'
@@ -49,13 +45,7 @@ GraphDiss2 <- function(G) {
 #' @export
 natural.connectivity <- function(G, eig=NULL, norm=TRUE) {
   if (is.null(eig)) {
-#    arploaded <- tryCatch(library(rARPACK), error=function(e) FALSE)
-#    if (!arploaded) {
-#      warning('install rARPACK for fast, sparse eigen decomp, proceeding with eigen')
       eig <- eigen(G)
-#    } else {
-#      eig <- eigs_sym(G, k=ncol(G))
-#    }
   }
   estrind <- exp(eig$values)
   nc <- log(mean(estrind))
@@ -66,66 +56,6 @@ natural.connectivity <- function(G, eig=NULL, norm=TRUE) {
   return(nc)
 }
 
-### DEPRECATED
-##.tnorm <- function(x) {
-###   xs <- sum(x+1)
-###   (x+1)/xs
-##  if (all(x==0)) x
-##  else x/sum(x)
-##}
-
-
-#egraphletlist <- function(G, norm=TRUE) {
-#  ## assume G1, G2 are sparse Matrix objects
-#  Elist  <-  (Matrix::summary(as(G, 'symmetricMatrix'))[,-3])
-##  n <- length(orbind)
-#  if (ncol(Elist) < 1 || nrow(Elist < 1))
-#    return(replicate(12, Matrix(0, nrow(G), nrow(G)), simplify=FALSE))
-#  gcount <- orca::ecount4(Elist)
-#  if (norm) {
-#    p <- nrow(G)
-#    normv <- c(choose(p, 2), rep(choose(p, 3), 3), rep(choose(p, 4), 8))
-#  }
-##  if (max(Elist) < nrow(G)) {
-#### if edges are missing from nodes at the end of the graph, add them back
-##      gextra <- matrix(0, nrow=nrow(G)-max(Elist), ncol=15)
-##      gcount <- rbind(gcount, gextra)
-##  }
-#  ## expand to all possible edges
-#  ind    <- (Elist[,2]-1)*nrow(G) + Elist[,1]
-#  revind <- (Elist[,1]-1)*ncol(G) + Elist[,2]
-#  grlist <- vector('list', ncol(gcount))
-#  return(lapply(1:12, function(i) {
-#    gvec <- gcount[,i]
-#    if (norm) gvec <- gvec/normv[i]
-#    gmat <- Matrix(0, nrow=nrow(G), ncol=ncol(G))
-#    gmat[ind]    <- gvec
-#    gmat[revind] <- gvec
-#    gmat
-#  }))
-###  gcor <- cor(rbind(gcount[,orbind],1), method='spearman')
-###  gcor[upper.tri(gcor)]
-#}
-
-
-#vgraphletlist <- function(G, orbind=c(0, 2, 5, 7, 8, 10, 11, 6, 9, 4, 1)+1) {
-#  ## assume G1, G2 are sparse Matrix objects
-#  Elist  <-  orca:::convert.graph(Matrix::summary(as(G, 'symmetricMatrix'))[,-3])
-##  n <- length(orbind)
-#  if (ncol(Elist) < 1) return(matrix(0, nrow(G), 15))
-##  library(orca)
-#  gcount <- .C("count4", Elist, dim(Elist),
-#      orbits = matrix(0, nrow = max(Elist), ncol = 15), PACKAGE="orca")$orbits #orca::count4(Elist) #
-#  if (max(Elist) < nrow(G)) {
-### if edges are missing from nodes at the end of the graph, add them back
-#      gextra <- matrix(0, nrow=nrow(G)-max(Elist), ncol=15)
-#      gcount <- rbind(gcount, gextra)
-#  }
-#  return(gcount)
-#  ## expand to all possible edges
-###  gcor <- cor(rbind(gcount[,orbind],1), method='spearman')
-###  gcor[upper.tri(gcor)]
-#}
 
 #' @keywords internal
 .adj2elist <- function(G) {

--- a/R/pulsar-package.R
+++ b/R/pulsar-package.R
@@ -54,7 +54,7 @@ NULL
 #'   path <- lapply(lambda, function(lam) {
 #'     tmp <- abs(S) > lam
 #'     diag(tmp) <- FALSE
-#'     as(tmp, 'lsCMatrix')
+#'     as(tmp, 'lMatrix')
 #'   })
 #'   list(path=path)
 #' }
@@ -74,7 +74,7 @@ NULL
 #'     est$path <-  lapply(seq(length(lambda)), function(i) {
 #'                    ## convert precision array to adj list
 #'                    tmp <- est$X[,,i]; diag(tmp) <- 0
-#'                  as(tmp!=0, "lgCMatrix")
+#'                  as(tmp!=0, "lMatrix")
 #'     })
 #'     est
 #' }
@@ -84,7 +84,7 @@ NULL
 #'      est <- clime(data, lambda, ...)
 #'      est$path <- lapply(est$Omegalist, function(x) {
 #'                      diag(x) <- 0
-#'                      as(abs(x) > tol, "dsCMatrix")
+#'                      as(abs(x) > tol, "lMatrix")
 #'                  })
 #'      est
 #' }
@@ -95,7 +95,7 @@ NULL
 #'      path <- lapply(lambda, function(lam) {
 #'                      tmp <- invcov.shrink(data, lam, verbose=FALSE)
 #'                      diag(tmp) <- 0
-#'                      as(abs(tmp) > tol, "lsCMatrix")
+#'                      as(abs(tmp) > tol, "lMatrix")
 #'                  })
 #'      list(path=path)
 #' }
@@ -106,7 +106,7 @@ NULL
 #'          n <- length(lambda)
 #'          tmp <- glmnet(data[,-respind], data[,respind],
 #'                                    family=family, lambda=lambda, ...)
-#'          path <-lapply(1:n, function(i) as(tmp$beta[,i,drop=FALSE], "lgCMatrix"))
+#'          path <-lapply(1:n, function(i) as(tmp$beta[,i,drop=FALSE], "lMatrix"))
 #'          list(path=path)
 #' }
 #'

--- a/tests/testthat/pulsarfuns.R
+++ b/tests/testthat/pulsarfuns.R
@@ -1,20 +1,9 @@
-# quicr <- function(data, lambda) {
-#     S    <- cor(data)
-#     est  <- QUIC::QUIC(S, rho=1, path=lambda, msg=0, tol=1e-2)
-#     path <-  lapply(seq(length(lambda)), function(i) {
-#                 tmp <- est$X[,,i]; diag(tmp) <- 0
-#                 as(tmp!=0, "lgCMatrix")
-#     })
-#     est$path <- path
-#     est
-# }
-
 quicr <- function(data, lambda, seed=NULL) {
     est  <- BigQuic::BigQuic(data, lambda=lambda, epsilon=1e-2, use_ram=TRUE, seed=seed)
     est <- setNames(lapply(ls(envir=est), mget, envir=attr(unclass(est), '.xData')), ls(envir=est))
     path <-  lapply(seq(length(lambda)), function(i) {
                 tmp <- est$precision_matrices[[1]][[i]]; diag(tmp) <- 0
-                as(tmp!=0, "lgCMatrix")
+                as(tmp!=0, "lMatrix")
     })
     est$path <- path
     est


### PR DESCRIPTION
Address #20. Future-proof for Matrix package v1.4-2, which will disallow a few convenient matrix conversion tools.

Also, remove some commented-out/deprecated code and one new Note about a bad S3 class check.