### PR TITLE
Fix the BigQuic function in tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pulsar
 Title: Parallel Utilities for Lambda Selection along a Regularization Path
-Version: 0.3.8
+Version: 0.3.9
 Encoding: UTF-8
 Authors@R: c(person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
              person("Christian", "M\u00FCller", role = c("aut", "ctb"), email="cmueller@simonsfoundation.org"))
@@ -32,5 +32,5 @@ Imports:
     utils,
     tools,
     Matrix
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+pulsar 0.3.9 (1-2023 Release)
+==============
+
+* Fix BigQuic-dependent tests
+
+
 pulsar 0.3.8 (8-2022 Release)
 ==============
 

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ pulsar 0.3.8 (8-2022 Release)
 
 * Future-proof sparse Matrix convertors for Matrix-1.4-2 in code and docs
 * Fix one S3 class check
+* Fixed broken urls in docs
 
 pulsar 0.3.7 (7-2020 Release)
 ==============

--- a/tests/testthat/test_batchtools.R
+++ b/tests/testthat/test_batchtools.R
@@ -59,11 +59,6 @@ test_that("batch.pulsar options", {
             rep.num=3, lb.stars=TRUE, wkdir=tmpdir, refit=FALSE))
   test_all(est)
 
-  # suppressWarnings(
-  #   est <- batch.pulsar(dat$data, huge::huge, fargs,
-  #           rep.num=3, lb.stars=TRUE, wkdir=tmpdir, refit=TRUE))
-  # test_all(est, 1:3)
-
   suppressWarnings(est <- batch.pulsar(dat$data, huge::huge, fargs, rep.num=3, lb.stars=TRUE, cleanup=TRUE, wkdir=tmpdir, refit=FALSE))
   test_all(est, cleanup=TRUE)
 

--- a/tests/testthat/test_pulsar.R
+++ b/tests/testthat/test_pulsar.R
@@ -8,9 +8,9 @@ source('pulsarfuns.R')
 rseed <- 10010
 p     <- 30
 set.seed(rseed)
-dat <- huge::huge.generator(p*100, p, "hub", verbose=FALSE, v=.4, u=.2)
+dat <- huge::huge.generator(p*30, p, "hub", verbose=FALSE, v=.4, u=.2)
 set.seed(rseed)
-dat$data <- MASS::mvrnorm(p*100, mu=rep(0,p), Sigma=dat$sigma, empirical=TRUE)
+dat$data <- MASS::mvrnorm(p*30, mu=rep(0,p), Sigma=dat$sigma, empirical=TRUE)
 
 tmpdir <- fs::path_real(tempdir())
 conffile <- ""


### PR DESCRIPTION
Turned out to be a minor issue causing failing tests.

This should get pulsar back on CRAN.