### PR TITLE
factor BigQuic out of tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pulsar
 Title: Parallel Utilities for Lambda Selection along a Regularization Path
-Version: 0.3.9
+Version: 0.3.10
 Encoding: UTF-8
 Authors@R: c(person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
              person("Christian", "M\u00FCller", role = c("aut", "ctb"), email="cmueller@simonsfoundation.org"))
@@ -17,7 +17,7 @@ Suggests:
     orca,
     huge,
     MASS,
-    BigQuic,
+    clime,
     glmnet,
     network,
     cluster,

--- a/tests/testthat/test_pulsar.R
+++ b/tests/testthat/test_pulsar.R
@@ -6,7 +6,7 @@ options(batchtools.progress=FALSE)
 source('pulsarfuns.R')
 
 rseed <- 10010
-p     <- 30
+p     <- 15
 set.seed(rseed)
 dat <- huge::huge.generator(p*30, p, "hub", verbose=FALSE, v=.4, u=.2)
 set.seed(rseed)
@@ -25,10 +25,10 @@ huge.serial.refit <- runtests(pulsar, "pulsar", dat, fun=huge::huge,
                         fargs=pargs, seed=rseed, refit=TRUE)
 
 ######################################################
-context(sprintf(cstr, 'quic', 'serial'))
-quic.serial       <- runtests(pulsar, "pulsar", dat, fun=quicr,
+context(sprintf(cstr, 'clime', 'serial'))
+clime.serial       <- runtests(pulsar, "pulsar", dat, fun=climer,
                               fargs=list(seed=rseed), seed=rseed, refit=FALSE)
-quic.serial.refit <- runtests(pulsar, "pulsar", dat, fun=quicr,
+clime.serial.refit <- runtests(pulsar, "pulsar", dat, fun=climer,
                               fargs=list(seed=rseed), seed=rseed, refit=TRUE)
 
 ######################################################
@@ -41,11 +41,11 @@ huge.batch.refit <- runtests(batch.pulsar, "batch.pulsar", dat, fun=huge::huge,
                        seed=rseed, wkdir=tmpdir, refit=TRUE)
 
 ######################################################
-context(sprintf(cstr, 'quic', 'batch', ''))
-quic.batch       <- runtests(batch.pulsar, "batch.pulsar", dat, fun=quicr,
+context(sprintf(cstr, 'clime', 'batch', ''))
+clime.batch       <- runtests(batch.pulsar, "batch.pulsar", dat, fun=climer,
                              fargs=list(seed=rseed), conffile=conffile, cleanup=TRUE,
                              seed=rseed, wkdir=tmpdir, refit=FALSE)
-quic.batch.refit <- runtests(batch.pulsar, "batch.pulsar", dat, fun=quicr,
+clime.batch.refit <- runtests(batch.pulsar, "batch.pulsar", dat, fun=climer,
                              fargs=list(seed=rseed), conffile=conffile, cleanup=TRUE,
                              seed=rseed, wkdir=tmpdir, refit=TRUE)
 
@@ -56,10 +56,10 @@ msg2 <- "huge: serial and batch mode are equivilent: lower bound"
 runcomptest(msg,  huge.serial$out,   huge.batch$out)
 runcomptest(msg2, huge.serial$outb, huge.batch$outb)
 
-msg  <- "quic: serial and batch mode are equivilent: no bounds"
-msg2 <- "quic: serial and batch mode are equivilent: lower bound"
-runcomptest(msg,  quic.serial$out,   quic.batch$out)
-runcomptest(msg2, quic.serial$outb, quic.batch$outb)
+msg  <- "clime: serial and batch mode are equivilent: no bounds"
+msg2 <- "clime: serial and batch mode are equivilent: lower bound"
+runcomptest(msg,  clime.serial$out,   clime.batch$out)
+runcomptest(msg2, clime.serial$outb, clime.batch$outb)
 
 #######################################################
 context("pulsar: refit mode")
@@ -73,15 +73,15 @@ msg2 <- "huge: batch refit test: lower bound"
 runcomptest(msg, huge.batch$out,  huge.batch.refit$out)
 runcomptest(msg, huge.batch$outb, huge.batch.refit$outb)
 
-msg  <- "quic: serial refit test: no bounds"
-msg2 <- "quic: serial refit test: lower bound"
-runcomptest(msg, quic.serial$out,  quic.serial.refit$out)
-runcomptest(msg, quic.serial$outb, quic.serial.refit$outb)
+msg  <- "clime: serial refit test: no bounds"
+msg2 <- "clime: serial refit test: lower bound"
+runcomptest(msg, clime.serial$out,  clime.serial.refit$out)
+runcomptest(msg, clime.serial$outb, clime.serial.refit$outb)
 
-msg  <- "quic: batch refit test: no bounds"
-msg2 <- "quic: batch refit test: lower bound"
-runcomptest(msg, quic.batch$out,  quic.batch.refit$out)
-runcomptest(msg, quic.batch$outb, quic.batch.refit$outb)
+msg  <- "clime: batch refit test: no bounds"
+msg2 <- "clime: batch refit test: lower bound"
+runcomptest(msg, clime.batch$out,  clime.batch.refit$out)
+runcomptest(msg, clime.batch$outb, clime.batch.refit$outb)
 
 
 #######################################################
@@ -92,8 +92,8 @@ testrefit("refitting batch pulsar gives correct warnings & output", huge.batch$o
 testrefit("prefitting pulsar gives correct warnings & output", huge.serial.refit$outb)
 testrefit("prefitting batch pulsar gives correct warnings & output", huge.batch.refit$outb)
 
-testrefit("refitting pulsar gives correct warnings & output", quic.serial$outb)
-testrefit("refitting batch pulsar gives correct warnings & output", quic.batch$outb)
+testrefit("refitting pulsar gives correct warnings & output", clime.serial$outb)
+testrefit("refitting batch pulsar gives correct warnings & output", clime.batch$outb)
 
-testrefit("prefitting pulsar gives correct warnings & output", quic.serial.refit$outb)
-testrefit("prefitting batch pulsar gives correct warnings & output", quic.batch.refit$outb)
+testrefit("prefitting pulsar gives correct warnings & output", clime.serial.refit$outb)
+testrefit("prefitting batch pulsar gives correct warnings & output", clime.batch.refit$outb)


### PR DESCRIPTION
Switch from `BigQuic` to `clime` for tests. This was unstable and hogging memory on mac m1 chipsets.