### PR TITLE
Fix huge on linux-gcc

### DIFF
--- a/.github/workflows/test-gcc.yaml
+++ b/.github/workflows/test-gcc.yaml
@@ -1,0 +1,31 @@
+name: Test GCC + OpenMP
+
+on: [push, pull_request]
+
+jobs:
+  test-gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libxml2-dev libssl-dev libgomp1 libgmp-dev
+
+      - name: Install R deps from source
+        run: |
+          Rscript -e 'install.packages(c("testthat", "Matrix", "batchtools", "fs", "checkmate", "MASS", "huge", "clime", "orca", "glmnet", "network", "cluster", "knitr", "rmarkdown"), type = "source", repos = "https://cloud.r-project.org")'
+
+      - name: Install pulsar
+        run: R CMD INSTALL .
+
+      - name: Verify huge uses libgomp
+        run: |
+          Rscript -e 'cat(system2("ldd", c(system.file("libs", "huge.so", package="huge")), stdout=TRUE), sep="\n")'
+
+      - name: Run tests
+        run: Rscript -e 'testthat::test_dir("tests/testthat")'
+        timeout-minutes: 10

--- a/.github/workflows/test-gcc.yaml
+++ b/.github/workflows/test-gcc.yaml
@@ -27,5 +27,6 @@ jobs:
           Rscript -e 'cat(system2("ldd", c(system.file("libs", "huge.so", package="huge")), stdout=TRUE), sep="\n")'
 
       - name: Run tests
-        run: Rscript -e 'testthat::test_dir("tests/testthat")'
+        run: Rscript -e 'library(testthat); library(pulsar); test_check("pulsar")'
+        working-directory: tests
         timeout-minutes: 10

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pulsar
 Title: Parallel Utilities for Lambda Selection along a Regularization Path
-Version: 0.3.12
+Version: 0.3.13
 Encoding: UTF-8
 Authors@R: c(person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
              person("Christian", "M\u00FCller", role = c("aut", "ctb"), email="cmueller@simonsfoundation.org"))

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,11 @@
-pulsar 0.3.12 (3-2026 Release)
+pulsar 0.3.13
 ==============
 * Replace mclapply (fork-based) with parLapply (PSOCK cluster) when ncores > 1, fixing OpenMP+fork deadlocks on GCC/Linux (CRAN r-devel-linux-x86_64-fedora-gcc)
 * Multi-core mode now works on Windows
+
+
+pulsar 0.3.12 (3-2026 Release)
+==============
 * Guard examples and vignettes against missing suggested packages (fixes CRAN noSuggests check failures)
 * Pin huge (>= 1.5) in Suggests
 * Use arXiv DOI format in Description field

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 pulsar 0.3.12 (3-2026 Release)
 ==============
+* Replace mclapply (fork-based) with parLapply (PSOCK cluster) when ncores > 1, fixing OpenMP+fork deadlocks on GCC/Linux (CRAN r-devel-linux-x86_64-fedora-gcc)
+* Multi-core mode now works on Windows
 * Guard examples and vignettes against missing suggested packages (fixes CRAN noSuggests check failures)
 * Pin huge (>= 1.5) in Suggests
 * Use arXiv DOI format in Description field

--- a/R/mcPulsarSelect.R
+++ b/R/mcPulsarSelect.R
@@ -48,17 +48,31 @@
 
 #' @keywords internal
 .try_mclapply <- function(X, FUN, mc.cores = getOption("mc.cores", 2L),
-                          pass.errors=TRUE, ...) {
-  ## capture errors/warnings from mclapply
+                          pass.errors=TRUE, mc.preschedule = TRUE, ...) {
   warn <- NULL
   env <- environment()
-  withCallingHandlers({out <- mclapply(X, FUN, mc.cores=mc.cores, ...)},
-                      warning=function(w) {
-                         # why doesn't assignment mode work when ncores>1
-                         assign('warn', c(warn, w$message), env)
-                         invokeRestart("muffleWarning")
-                       })
-  ## handle errors
+
+  if (mc.cores > 1L) {
+    cl <- parallel::makePSOCKcluster(mc.cores)
+    on.exit(parallel::stopCluster(cl))
+    safe_fun <- function(x, ...) {
+      tryCatch(FUN(x, ...), error = function(e) {
+        structure(conditionMessage(e), class = "try-error")
+      })
+    }
+    if (mc.preschedule) {
+      out <- parallel::parLapply(cl, X, safe_fun, ...)
+    } else {
+      out <- parallel::parLapplyLB(cl, X, safe_fun, ...)
+    }
+  } else {
+    withCallingHandlers({out <- mclapply(X, FUN, mc.cores=1L, ...)},
+                        warning=function(w) {
+                           assign('warn', c(warn, w$message), env)
+                           invokeRestart("muffleWarning")
+                         })
+  }
+
   errors <- sapply(out, inherits, what="try-error")
   if (any(errors)) {
     error <- table(trimws(sapply(out[errors], '[', 1)))
@@ -68,11 +82,9 @@
       stop(msg, call.=FALSE)
     } else {
       warning(msg, call.=FALSE)
-      ## continue with successful jobs
       out <- out[!errors]
     }
   } else {
-    ## will only invoke if ncore=1, otherwise mclapply suppresses warnings
     if (length(warn) > 0) {
       twarn <- table(trimws(sapply(warn, '[', 1)))
       msg   <- paste(sprintf('%s job%s had warning: "%s"',
@@ -80,10 +92,8 @@
                       collapse="\n")
       warning(msg, call.=FALSE)
     }
-  }## no errors detected, continue
+  }
 
-  # reset previous warn option
-  # options(warn=warn.opt)
   attr(out, 'errors') <- errors
   return(out)
 }
@@ -103,7 +113,7 @@
 #' @param seed A numeric seed to force predictable subsampling. Default is NULL. Use for testing purposes only.
 #' @param lb.stars Should the lower bound be computed after the first \eqn{N=2} subsamples (should result in considerable speedup and only implemented if stars is selected). If this option is selected, other summary metrics will only be applied to the smaller lambda path.
 #' @param ub.stars Should the upper bound be computed after the first \eqn{N=2} subsamples (should result in considerable speedup and only implemented if stars is selected). If this option is selected, other summary metrics will only be applied to the smaller lambda path. This option is ignored if the lb.stars flag is FALSE.
-#' @param ncores number of cores to use for subsampling. See \code{batch.pulsar} for more parallelization options.
+#' @param ncores number of cores to use for subsampling. When \code{ncores > 1}, a PSOCK cluster is used (via \code{\link[parallel]{parLapply}}) to avoid fork-safety issues with OpenMP libraries. See \code{batch.pulsar} for more parallelization options.
 #' @param refit Boolean flag to refit on the full dataset after pulsar is run. (see also \code{\link{refit}})
 #'
 #' @return an S3 object of class \code{pulsar} with a named member for each stability metric run. Within each of these are:

--- a/tests/testthat/test_errorreporting.R
+++ b/tests/testthat/test_errorreporting.R
@@ -38,13 +38,11 @@ test_that("Job stops when every parallel job has errors", {
           rep.num=8, refit=FALSE, lb.stars=TRUE),
     regexp = "NA")
 
-  skip_on_os("windows")
   expect_error(
     pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
           rep.num=8, refit=FALSE),
     regexp = "NA")
 
-  skip_on_os("windows")
   expect_error(
     pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=1, seed=rseed,
           rep.num=8, refit=FALSE, lb.stars=TRUE),
@@ -65,14 +63,12 @@ test_that("Job continues when subset of parallel jobs have errors/warnings", {
           rep.num=8, refit=FALSE, lb.stars=TRUE),
     regexp = "NA")
 
-  skip_on_os("windows")
   expect_warning(
     filter_warning(
       out1 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,
             seed=rseed, rep.num=8, refit=FALSE), "Optimal lambda"),
     regexp = "NA")
 
-  skip_on_os("windows")
   expect_warning(
     filter_warning(
       out2 <- pulsar(X, fun=huge_error, hargs, ncores=2, subsample.ratio=.5,


### PR DESCRIPTION
CRAN checks are [failing](https://cran.r-project.org/web/checks/check_results_pulsar.html) on linux GCC flavors. Huge 1.5+ is now using libomp for multi-threading but this doesn't work when combined with multi-core ( OpenMP+mclapply  fork deadlocks).

Therefore, I need to switch to parLapply and use a PSOCK cluster. However, data has to be copied in RAM so that's a bummer. We do get parallel workflows on windows now so that's a plus.

Bumps to v0.3.13.
